### PR TITLE
feat: Add CPU mode as default for better compatibility

### DIFF
--- a/.claude-mcp-config.json
+++ b/.claude-mcp-config.json
@@ -6,7 +6,8 @@
       "cwd": "/home/flopes/snipr",
       "env": {
         "INDEX_CACHE_DIR": ".index_cache",
-        "ENABLE_QUANTIZATION": "true"
+        "ENABLE_QUANTIZATION": "true",
+        "DEVICE": "cpu"
       }
     }
   }

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ INDEX_CACHE_DIR=.index_cache
 
 # Embedding Model Configuration
 EMBEDDING_MODEL=all-MiniLM-L6-v2
+# Device for model inference (cpu or cuda)
+# Default is cpu for better compatibility
+DEVICE=cpu
 
 # Performance Settings
 MAX_FILE_SIZE_MB=10

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ EMBEDDING_MODEL="all-MiniLM-L6-v2"
 
 # Batch size for embedding generation
 EMBEDDING_BATCH_SIZE="32"
+
+# Device for model inference (cpu or cuda)
+# Default is cpu for better compatibility
+DEVICE="cpu"
 ```
 
 ### Performance Tuning
@@ -273,6 +277,20 @@ Reduce batch size for lower memory usage:
 
 ```bash
 export BATCH_SIZE="16"
+```
+
+### GPU/CUDA Issues
+
+The tool defaults to CPU mode for better compatibility. To use GPU:
+
+```bash
+export DEVICE="cuda"
+```
+
+To force CPU mode (default):
+
+```bash
+export DEVICE="cpu"
 ```
 
 ## Requirements

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,10 @@ class Config:
     _embedding_enabled_env = os.getenv("EMBEDDING_ENABLED", "true").lower()
     EMBEDDING_ENABLED: bool = _embedding_enabled_env == "true"
     EMBEDDING_BATCH_SIZE: int = int(os.getenv("EMBEDDING_BATCH_SIZE", "32"))
+    
+    # Device configuration (cpu or cuda)
+    # Default to CPU for better compatibility
+    DEVICE: str = os.getenv("DEVICE", "cpu").lower()
 
     # Search performance configuration
     MAX_FILE_SIZE_MB: int = int(os.getenv("MAX_FILE_SIZE_MB", "10"))

--- a/src/config.py
+++ b/src/config.py
@@ -12,7 +12,7 @@ class Config:
     _embedding_enabled_env = os.getenv("EMBEDDING_ENABLED", "true").lower()
     EMBEDDING_ENABLED: bool = _embedding_enabled_env == "true"
     EMBEDDING_BATCH_SIZE: int = int(os.getenv("EMBEDDING_BATCH_SIZE", "32"))
-    
+
     # Device configuration (cpu or cuda)
     # Default to CPU for better compatibility
     DEVICE: str = os.getenv("DEVICE", "cpu").lower()

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -45,8 +45,10 @@ class SearchService:
             return
 
         try:
-            self.model = SentenceTransformer(self.config.EMBEDDING_MODEL)
-            logger.info(f"Initialized embedding model: {self.config.EMBEDDING_MODEL}")
+            # Initialize with specified device (cpu or cuda)
+            device = self.config.DEVICE
+            self.model = SentenceTransformer(self.config.EMBEDDING_MODEL, device=device)
+            logger.info(f"Initialized embedding model: {self.config.EMBEDDING_MODEL} on device: {device}")
         except Exception as e:
             logger.error(f"Failed to initialize embedding model: {e}")
             self.model = None


### PR DESCRIPTION
## Summary

This PR adds CPU mode as the default configuration for the Snipr tool to ensure better compatibility across different systems.

## Changes

- ✨ Added `DEVICE` configuration option in `src/config.py` to control CPU/CUDA usage
- 🔧 Modified `search_service.py` to respect the DEVICE setting when initializing the embedding model
- 📝 Updated `.env.example` with the new DEVICE configuration
- 🔧 Updated `.claude-mcp-config.json` to explicitly set CPU mode
- 📚 Added documentation in README.md about device configuration

## Motivation

Many users may face GPU/CUDA compatibility issues (as seen during testing). By defaulting to CPU mode:
- The tool works reliably out of the box on all systems
- Users with compatible GPUs can still opt-in by setting `DEVICE=cuda`
- Eliminates CUDA-related errors for users without compatible GPUs

## Testing

- ✅ Tested with CPU mode explicitly set
- ✅ Verified embedding model initializes correctly with device configuration
- ✅ Confirmed tool functions properly in CPU mode

## Breaking Changes

None. This change is backward compatible. Users who want to use GPU can set `DEVICE=cuda` in their environment.

## Related Issues

Addresses GPU compatibility issues discovered during testing where CUDA errors prevented the tool from functioning on systems with incompatible GPUs.